### PR TITLE
Add additional fields from Accuweather API

### DIFF
--- a/lib/currentCondObject.json
+++ b/lib/currentCondObject.json
@@ -69,7 +69,7 @@
         "type": "state",
         "common": {
             "name": "Precipitation Description",
-            "type": "boolean",
+            "type": "string",
             "read": true,
             "write": false,
             "role": "value"
@@ -140,11 +140,22 @@
         "type": "state",
         "common": {
             "name": "Wind Direction",
-            "type": "string",
+            "type": "number",
             "read": true,
             "write": false,
             "role": "value.direction.wind",
             "unit": "°"
+        },
+        "native": {}
+    },
+    "nextHour.WindDirectionText": {
+        "type": "state",
+        "common": {
+            "name": "Wind Direction Text",
+            "type": "string",
+            "read": true,
+            "write": false,
+            "role": "value.direction.wind"
         },
         "native": {}
     },
@@ -168,6 +179,18 @@
             "read": true,
             "write": false,
             "role": "value.humidity",
+            "unit": "%"
+        },
+        "native": {}
+    },
+    "nextHour.CloudCover": {
+        "type": "state",
+        "common": {
+            "name": "Cloud Cover",
+            "type": "number",
+            "read": true,
+            "write": false,
+            "role": "value",
             "unit": "%"
         },
         "native": {}

--- a/main.js
+++ b/main.js
@@ -169,6 +169,7 @@ class Accuweather extends utils.Adapter {
 					if (key === "Wind") {
 						this.setState("Hourly.h" + hour + ".WindSpeed", { val: json[key].Speed.Value, ack: true });
 						this.setState("Hourly.h" + hour + ".WindDirection", { val: json[key].Direction.Degrees, ack: true });
+						this.setState("Hourly.h" + hour + ".WindDirectionText", { val: json[key].Direction.Localized , ack: true });
 					} else
 					if (key === "WindGust") {
 						this.setState("Hourly.h" + hour + ".WindGust", { val: json[key].Speed.Value, ack: true });
@@ -215,6 +216,7 @@ class Accuweather extends utils.Adapter {
 						this.setState("Current.WindSpeed", { val: json[key].Speed.Metric.Value, ack: true });
 						this.setState("Summary.WindSpeed", { val: json[key].Speed.Metric.Value, ack: true });
 						this.setState("Current.WindDirection", { val: json[key].Direction.Degrees, ack: true });
+						this.setState("Current.WindDirectionText", { val: json[key].Direction.Localized, ack: true });
 						this.setState("Summary.WindDirection", { val: json[key].Direction.Degrees, ack: true });
 						this.setState("Summary.WindDirectionStr", { val: this.getCardinalDirection(json[key].Direction.Degrees), ack: true });
 					} else


### PR DESCRIPTION
Hallo
ich habe versucht zwei weitere Felder aus der Accuweather API dem Current und Hourly Wetter Status hinzuzufügen.
Die beiden Felder sind:
Wind.Direction.Localized 
CloudCover
Daneben habe ich an ein paar Stellen den Typ der Felder an den Datentyp aus Accuweather angepasst.
Wäre super wenn das in den Adapter übernommen werden könnte.